### PR TITLE
DLP.cpp: mark logs as DEBUG_ONLY

### DIFF
--- a/src/DLP.cpp
+++ b/src/DLP.cpp
@@ -32,10 +32,10 @@ void DLP::CheckHelloTag(CUpDownClient* c, UINT tagn){
 	PRE_CHECK(PF_HELLOTAG){
 		const wxChar* dlp_result = antiLeech->DLPCheckHelloTag(tagn);
 		if(dlp_result != NULL) {
-			wxString ret;
-			ret.Printf(_("[HelloTag %s] %s"), dlp_result, c->GetClientFullInfo().c_str());
+			DEBUG_ONLY(wxString ret);
+			DEBUG_ONLY(ret.Printf(_("[HelloTag %s] %s"), dlp_result, c->GetClientFullInfo().c_str()));
 			c->Ban();
-			theApp->AddDLPMessageLine(ret);
+			DEBUG_ONLY(theApp->AddDLPMessageLine(ret));
 		}
 	}
 }
@@ -44,10 +44,10 @@ void DLP::CheckInfoTag(CUpDownClient* c, UINT tagn){
 	PRE_CHECK(PF_INFOTAG){
 		const wxChar* dlp_result = antiLeech->DLPCheckInfoTag(tagn);
 		if(dlp_result != NULL) {
-			wxString ret;
-			ret.Printf(_("[InfoTag %s] %s"), dlp_result, c->GetClientFullInfo().c_str());
+			DEBUG_ONLY(wxString ret);
+			DEBUG_ONLY(ret.Printf(_("[InfoTag %s] %s"), dlp_result, c->GetClientFullInfo().c_str()));
 			c->Ban();
-			theApp->AddDLPMessageLine(ret);
+			DEBUG_ONLY(theApp->AddDLPMessageLine(ret));
 		}
 	}
 }
@@ -100,10 +100,10 @@ bool DLP::DLPCheck(CUpDownClient* c){
 	
 	if (tmp != NULL) {
 		ret = tmp;
-		wxString wxInfo;
-		wxInfo.Printf(wxT("[%s] %s"), ret.c_str(), c->GetClientFullInfo().c_str());
+		DEBUG_ONLY(wxString wxInfo);
+		DEBUG_ONLY(wxInfo.Printf(wxT("[%s] %s"), ret.c_str(), c->GetClientFullInfo().c_str()));
 		c->Ban();
-		theApp->AddDLPMessageLine(wxInfo);
+		DEBUG_ONLY(theApp->AddDLPMessageLine(wxInfo));
 		return true;
 	}
 


### PR DESCRIPTION
In updownclient.h, c->GetClientFullInfo was marked as DEBUG_ONLY.
When we compile it with non-debug mode, few logs in DLP.cpp are still
trying to access GetClientFullInfo, which is not exist, and causes
following build errors:

```
DLP.cpp: In member function ‘void DLP::CheckHelloTag(CUpDownClient*, wxUint16)’:
DLP.cpp:36:53: error: ‘class CUpDownClient’ has no member named ‘GetClientFullInfo’
    ret.Printf(_("[HelloTag %s] %s"), dlp_result, c->GetClientFullInfo().c_str());
                                                     ^
DLP.cpp: In member function ‘void DLP::CheckInfoTag(CUpDownClient*, wxUint16)’:
DLP.cpp:48:52: error: ‘class CUpDownClient’ has no member named ‘GetClientFullInfo’
    ret.Printf(_("[InfoTag %s] %s"), dlp_result, c->GetClientFullInfo().c_str());
                                                    ^
DLP.cpp: In member function ‘bool DLP::DLPCheck(CUpDownClient*)’:
DLP.cpp:104:49: error: ‘class CUpDownClient’ has no member named ‘GetClientFullInfo’
   wxInfo.Printf(wxT("[%s] %s"), ret.c_str(), c->GetClientFullInfo().c_str());
```

This commit marks these logs entries to DEBUG_ONLY, that matches with GetClientFullInfo
and resolves the issue.

Signed-off-by: Tom Li biergaizi@member.fsf.org
