### PR TITLE
Enable automake option subdir-objects.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -25,7 +25,7 @@
 #
 
 AC_INIT([aMule], [2.4.0], [admin@amule.org])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
 
 AC_PREREQ(2.59)


### PR DESCRIPTION
While running automake, errors occures, for not enabling subdir-objects.

I use the latest autotools form arch mirrors, so I believe this should be a problem.
